### PR TITLE
Differentiate police and ambulance calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,10 @@ setr lb-tablet-dispatch:default-time 100
 # Set the default locale for the various translations
 # Current locales: en
 setr lb-tablet-dispatch:locale en
+
+# Define which jobs should link to the police MDT/CAD
+setr lb-tablet-dispatch:police-jobs '["police", "sheriff", "leo"]'
+
+# Define which jobs should link to the ambulance MDT/CAD
+setr lb-tablet-dispatch:ambulance-jobs', '["ambulance", "hospital", "sams"]'
 ```

--- a/server/ps-dispatch.lua
+++ b/server/ps-dispatch.lua
@@ -17,6 +17,6 @@ RegisterNetEvent('ps-dispatch:server:notify', function (data)
           coords = vector2(data?.coords.x or 0, data?.coords.y or 0)
         },
         time = CONFIG['default-time'],
-        job = "police"
+        job = ReceivingJob(data.jobs)
     })
 end)

--- a/server/qs-dispatch.lua
+++ b/server/qs-dispatch.lua
@@ -15,6 +15,6 @@ RegisterNetEvent('qs-dispatch:server:CreateDispatchCall', function (data)
           coords = vector2(data?.callLocation.x or 0, data?.callLocation.y or 0)
         },
         time = data?.blip.time and math.floor(data.blip.time / 1000) or CONFIG['default-time'],
-        job = "police"
+        job = ReceivingJob(data.jobs)
     })
 end)

--- a/server/rcore-dispatch.lua
+++ b/server/rcore-dispatch.lua
@@ -16,6 +16,6 @@ RegisterNetEvent('rcore_dispatch:server:sendAlert', function(data)
             coords = vector2(data?.coords.x or 0, data?.coords.y or 0)
         },
         time = CONFIG['default-time'],
-        job = "police"
+        job = ReceivingJob(data.jobs)
     })
 end)

--- a/utils/convars.lua
+++ b/utils/convars.lua
@@ -1,4 +1,35 @@
 CONFIG = {
     ['default-time'] = GetConvarInt('lb-tablet-dispatch:default-time', 100),
-    ['locale'] = GetConvar('lb-tablet-dispatch:locale', 'en')
+    ['locale'] = GetConvar('lb-tablet-dispatch:locale', 'en'),
+    ['police-jobs'] = {},
+    ['ambulance-jobs'] = {},
 }
+
+local success, result, policeJobs, ambulanceJobs
+success, result = pcall(function()
+    return json.decode(GetConvar('lb-tablet-dispatch:police-jobs', '["police", "sheriff", "leo"]'))
+end)
+if success then
+    policeJobs = result
+else
+    print('[^1ERROR^7] Invalid JSON string for ^5police-jobs^7 convar ! Using default values.')
+    policeJobs = {"police", "sheriff", "leo"}
+end
+
+for _, job in pairs(policeJobs) do
+    CONFIG['police-jobs'][job] = true
+end
+
+success, result = pcall(function()
+    return json.decode(GetConvar('lb-tablet-dispatch:police-jobs', '["ambulance", "hospital", "sams"]'))
+end)
+if success then
+    ambulanceJobs = result
+else
+    print('[^1ERROR^7] Invalid JSON string for ^5ambulance-jobs^7 convar ! Using default values.')
+    ambulanceJobs = {"ambulance", "hospital", "sams"}
+end
+
+for _, job in pairs(ambulanceJobs) do
+    CONFIG['ambulance-jobs'][job] = true
+end

--- a/utils/convars.lua
+++ b/utils/convars.lua
@@ -21,7 +21,7 @@ for _, job in pairs(policeJobs) do
 end
 
 success, result = pcall(function()
-    return json.decode(GetConvar('lb-tablet-dispatch:police-jobs', '["ambulance", "hospital", "sams"]'))
+    return json.decode(GetConvar('lb-tablet-dispatch:ambulance-jobs', '["ambulance", "hospital", "sams"]'))
 end)
 if success then
     ambulanceJobs = result

--- a/utils/receivingJob.lua
+++ b/utils/receivingJob.lua
@@ -1,0 +1,27 @@
+function ReceivingJob(jobs)
+    local receivingJob
+    if type(jobs) == "table" then
+        for _, job in pairs(jobs) do
+            if CONFIG['police-jobs'][job] then
+                receivingJob = 'police'
+                break
+            elseif CONFIG['ambulance-jobs'][job] then
+                receivingJob = 'ambulance'
+                break
+            end
+        end
+    elseif type(jobs) == "string" then
+        if CONFIG['police-jobs'][jobs] then
+            receivingJob = 'police'
+        elseif CONFIG['ambulance-jobs'][jobs] then
+            receivingJob = 'ambulance'
+        end
+    end
+
+    if not receivingJob then
+        print('[^2WARNING^7] Invalid jobs or non parametered using the convars, refer to the setup documentation.')
+        return false
+    end
+
+    return receivingJob
+end


### PR DESCRIPTION
### Pull Request Description

A simple system used to redistribute dispatch message appropriately depending on the job.
Using the convars the users will be able to configure which jobs they have for ambulance and police.

## Major Changes

- Added convars
- Reworked server side dispatch integrations to use the job sorting

## Modifications done
- [x] 🍃 New Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🎨 Design
- [ ] 🔥 Optimization
- [ ] 🎒 Other
